### PR TITLE
outlineOTF: add cmap format 14 on codepoints outside BMP

### DIFF
--- a/Lib/ufo2fdk/outlineOTF.py
+++ b/Lib/ufo2fdk/outlineOTF.py
@@ -248,22 +248,46 @@ class OutlineOTFCompiler(object):
         table creation in a different way if desired.
         """
         from fontTools.ttLib.tables._c_m_a_p import cmap_format_4
+
+        nonBMP = dict((k,v) for k,v in self.unicodeToGlyphNameMapping.items() if k > 65535)
+        if nonBMP:
+            mapping = dict((k,v) for k,v in self.unicodeToGlyphNameMapping.items() if k <= 65535)
+        else:
+            mapping = dict(self.unicodeToGlyphNameMapping)
         # mac
         cmap4_0_3 = cmap_format_4(4)
         cmap4_0_3.platformID = 0
         cmap4_0_3.platEncID = 3
         cmap4_0_3.language = 0
-        cmap4_0_3.cmap = dict(self.unicodeToGlyphNameMapping)
+        cmap4_0_3.cmap = mapping
         # windows
         cmap4_3_1 = cmap_format_4(4)
         cmap4_3_1.platformID = 3
         cmap4_3_1.platEncID = 1
         cmap4_3_1.language = 0
-        cmap4_3_1.cmap = dict(self.unicodeToGlyphNameMapping)
+        cmap4_3_1.cmap = mapping
         # store
         self.otf["cmap"] = cmap = newTable("cmap")
         cmap.tableVersion = 0
         cmap.tables = [cmap4_0_3, cmap4_3_1]
+        # If we have glyphs outside Unicode BMP, we must set another
+        # subtable that can hold longer codepoints for them.
+        if nonBMP:
+            from fontTools.ttLib.tables._c_m_a_p import cmap_format_12
+            # mac
+            cmap12_0_3 = cmap_format_12(12)
+            cmap12_0_3.platformID = 0
+            cmap12_0_3.platEncID = 3
+            cmap12_0_3.language = 0
+            cmap12_0_3.cmap = nonBMP
+            # windows
+            cmap12_3_1 = cmap_format_12(12)
+            cmap12_3_1.platformID = 3
+            cmap12_3_1.platEncID = 1
+            cmap12_3_1.language = 0
+            cmap12_3_1.cmap = nonBMP
+            # update tables registry
+            cmap.tables = [cmap4_0_3, cmap4_3_1, cmap12_0_3, cmap12_3_1]
 
     def setupTable_OS2(self):
         """


### PR DESCRIPTION
Previously, ufo2fdk would crash on a UFO that has codepoints >0xFFFF.

r? @typesupply