### PR TITLE
makeotfParts: strip out comments in the feature file…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+*.pyc

--- a/Lib/ufo2fdk/makeotfParts.py
+++ b/Lib/ufo2fdk/makeotfParts.py
@@ -248,7 +248,8 @@ class MakeOTFPartsCompiler(object):
             features.append(text)
         for name, text in sorted(autoTables.items()):
             features.append(text)
-        features = "\n\n".join(features)
+        # strip-out comments from the features so to avoid non-ASCII chars
+        features = "\n\n".join([re.sub(r'#.*$', "", text) for text in features])
         # write the result
         f = open(path, "wb")
         f.write(features)


### PR DESCRIPTION
…so to avoid crashing upon encountering non-ASCII chars.

This brings ufo2fdk in feature-parity with Adobe's FDK in this regard.

r? @typesupply