### PR TITLE
Correct package list in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(name="ufo2fdk",
     author_email="tal@typesupply.com",
     url="http://code.typesupply.com",
     license="MIT",
-    packages=["ufo2fdk"],
+    packages=["ufo2fdk", "ufo2fdk.pens"],
     package_dir={"":"Lib"}
 )


### PR DESCRIPTION
When I build with the current setup.py script, the pens package doesn't get included.